### PR TITLE
Deploying images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-        at: ~/repo
+          at: ~/repo
       - run:
         name: Build the image
         command: docker build -t romppane/bulletin-board:$CIRCLE_SHA1 .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
     executor: my-executor
     steps:
       - run: curl https://cli-assets.heroku.com/install.sh | sh
-      - run: heroku container:release web
+      - run: heroku container:release web -a bulletin-board-onboarding-api
 
 workflows:
   btd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           command: docker push romppane/bulletin-board:$CIRCLE_SHA1
       - run:
           name: Login to registery
-          command: docker login --username=$HEROKU_LOGIN --$HEROKU_API_KEY registry.heroku.com
+          command: docker login --username=$HEROKU_LOGIN --password=$HEROKU_API_KEY registry.heroku.com
       - run:
           name: Deploy to Heroku
           command: docker tag romppane/bulletin-board:$CIRCLE_SHA1 registry.heroku.com/$HEROKU_APP_NAME/web

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,10 +62,10 @@ jobs:
           command: docker push romppane/bulletin-board:$CIRCLE_SHA1
       - run:
           name: Login to registery
-          command: docker login --username=$HEROKU_LOGIN --$HEROKU_API_KEY registery.heroku.com
+          command: docker login --username=$HEROKU_LOGIN --$HEROKU_API_KEY registry.heroku.com
       - run:
           name: Deploy to Heroku
-          command: docker tag romppane/bulletin-board:$CIRCLE_SHA1 registery.heroku.com/$HEROKU_APP_NAME/web
+          command: docker tag romppane/bulletin-board:$CIRCLE_SHA1 registry.heroku.com/$HEROKU_APP_NAME/web
 
 workflows:
   btd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           name: Login to registery
           command: docker login --username=$HEROKU_LOGIN --password=$HEROKU_API_KEY registry.heroku.com
       - run:
-          name: Deploy to Heroku
+          name: Tag image
           command: docker tag romppane/bulletin-board:$CIRCLE_SHA1 registry.heroku.com/$HEROKU_APP_NAME/web
       - run:
           name: Push to Heroku
@@ -68,7 +68,7 @@ jobs:
           command: curl https://cli-assets.heroku.com/install.sh | sh
       - run:
           name: Release the changes in Heroku
-          command: heroku container:release web -a bulletin-board-onboarding-api
+          command: heroku container:release web -a $HEROKU_APP_NAME
 
 workflows:
   btd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,9 +54,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/repo
-      - run:
-        name: Build the image
-        command: docker build -t romppane/bulletin-board:$CIRCLE_SHA1 .
+      - run: docker build -t romppane/bulletin-board:$CIRCLE_SHA1 .
 
 workflows:
   btd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,21 +52,18 @@ jobs:
       
       - run:
         name: Build the image
-        command: |
-        docker build -t romppane/bulletin-board:$CIRCLE_SHA1 .
+        command: docker build -t romppane/bulletin-board:$CIRCLE_SHA1 .
 
 
       - run:
         name: Push to DockerHub
-        command: |
-        docker login -u $DOCKERHUB_LOGIN -p $DOCKERHUB_PASSWORD
-        docker push romppane/bulletin-board:$CIRCLE_SHA1
+        command: docker login -u $DOCKERHUB_LOGIN -p $DOCKERHUB_PASSWORD
+        command: docker push romppane/bulletin-board:$CIRCLE_SHA1
 
       - run:
         name: Deploy to Heroku
-        command: |
-        docker login --username=$HEROKU_LOGIN --$HEROKU_API_KEY registery.heroku.com
-        docker tag romppane/bulletin-board:$CIRCLE_SHA1 registery.heroku.com/$HEROKU_APP_NAME/web
+        command: docker login --username=$HEROKU_LOGIN --$HEROKU_API_KEY registery.heroku.com
+        command: docker tag romppane/bulletin-board:$CIRCLE_SHA1 registery.heroku.com/$HEROKU_APP_NAME/web
 
 workflows:
   btd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,26 +54,9 @@ jobs:
       - checkout
       - attach_workspace:
         at: ~/repo
-
       - run:
         name: Build the image
         command: docker build -t romppane/bulletin-board:$CIRCLE_SHA1 .
-
-      - run:
-        name: Login to Docker
-        command: docker login -u $DOCKERHUB_LOGIN -p $DOCKERHUB_PASSWORD
-
-      - run:
-        name: Push to DockerHub
-        command: docker push romppane/bulletin-board:$CIRCLE_SHA1
-
-      - run:
-        name: Login to registery
-        command: docker login --username=$HEROKU_LOGIN --$HEROKU_API_KEY registery.heroku.com
-
-      - run:
-        name: Deploy to Heroku
-        command: docker tag romppane/bulletin-board:$CIRCLE_SHA1 registery.heroku.com/$HEROKU_APP_NAME/web
 
 workflows:
   btd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,5 +79,8 @@ workflows:
           requires:
             - build
       - deploy:
+          filters:
+            branches:
+              only: master
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
+            - build
 
   test:
     executor: my-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,20 +49,25 @@ jobs:
       - checkout
       - attach_workspace:
         at: ~/repo
-      
+
       - run:
         name: Build the image
         command: docker build -t romppane/bulletin-board:$CIRCLE_SHA1 .
 
+      - run:
+        name: Login to Docker
+        command: docker login -u $DOCKERHUB_LOGIN -p $DOCKERHUB_PASSWORD
 
       - run:
         name: Push to DockerHub
-        command: docker login -u $DOCKERHUB_LOGIN -p $DOCKERHUB_PASSWORD
         command: docker push romppane/bulletin-board:$CIRCLE_SHA1
 
       - run:
-        name: Deploy to Heroku
+        name: Login to registery
         command: docker login --username=$HEROKU_LOGIN --$HEROKU_API_KEY registery.heroku.com
+
+      - run:
+        name: Deploy to Heroku
         command: docker tag romppane/bulletin-board:$CIRCLE_SHA1 registery.heroku.com/$HEROKU_APP_NAME/web
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/repo
+      - setup_remote_docker
       - run: docker build -t romppane/bulletin-board:$CIRCLE_SHA1 .
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,9 @@ jobs:
     executor: my-executor
     steps:
       - run: curl https://cli-assets.heroku.com/install.sh | sh
-      - run: heroku login $HEROKU_API_KEY
+      - run: heroku login -i
+      - run: $HEROKU_LOGIN
+      - run: $HEROKU_API_KEY
       - run: heroku container:release web
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,9 @@ workflows:
           requires:
             - test
       - deploy:
+          filters:
+            branches:
+              only: master
           requires:
             - compile
       - release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,10 @@ executors:
     docker:
       - image: circleci/node:10.15.3
     working_directory: ~/repo
+  deployer:
+    docker:
+      - image: buildpack-deps:trusty
+    working_directory: ~/repo
 
 jobs:
   build:
@@ -45,7 +49,7 @@ jobs:
       - run: npm run tsc
 
   deploy:
-    machine: true
+    executor: deployer
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,6 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
 version: 2.1
-orbs:
-  heroku: circleci/heroku@0.0.8
 executors:
   my-executor:
     docker:
@@ -47,11 +45,28 @@ jobs:
       - run: npm run tsc
 
   deploy:
-    executor: heroku/default
     steps:
       - checkout
-      - heroku/install
-      - heroku/deploy-via-git
+      - attach_workspace:
+        at: ~/repo
+      
+      - run:
+        name: Build the image
+        command: |
+        docker build -t romppane/bulletin-board:$CIRCLE_SHA1 .
+
+
+      - run:
+        name: Push to DockerHub
+        command: |
+        docker login -u $DOCKERHUB_LOGIN -p $DOCKERHUB_PASSWORD
+        docker push romppane/bulletin-board:$CIRCLE_SHA1
+
+      - run:
+        name: Deploy to Heroku
+        command: |
+        docker login --username=$HEROKU_LOGIN --$HEROKU_API_KEY registery.heroku.com
+        docker tag romppane/bulletin-board:$CIRCLE_SHA1 registery.heroku.com/$HEROKU_APP_NAME/web
 
 workflows:
   btd:
@@ -64,8 +79,5 @@ workflows:
           requires:
             - test
       - deploy:
-          filters:
-            branches:
-              only: master
           requires:
             - compile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,8 +67,8 @@ jobs:
           name: Deploy to Heroku
           command: docker tag romppane/bulletin-board:$CIRCLE_SHA1 registry.heroku.com/$HEROKU_APP_NAME/web
       - run:
-        name: Release on Heroku
-        command: heroku container:release web
+          name: Release on Heroku
+          command: heroku container:release web
 
 workflows:
   btd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,6 @@ executors:
     docker:
       - image: circleci/node:10.15.3
     working_directory: ~/repo
-  deployer:
-    docker:
-      - image: buildpack-deps:trusty
-    working_directory: ~/repo
 
 jobs:
   build:
@@ -49,13 +45,27 @@ jobs:
       - run: npm run tsc
 
   deploy:
-    executor: deployer
+    executor: my-executor
     steps:
       - checkout
       - attach_workspace:
           at: ~/repo
       - setup_remote_docker
-      - run: docker build -t romppane/bulletin-board:$CIRCLE_SHA1 .
+      - run:
+          name: Build the image
+          command: docker build -t romppane/bulletin-board:$CIRCLE_SHA1 .
+      - run:
+          name: Login to Docker
+          command: docker login -u $DOCKERHUB_LOGIN -p $DOCKERHUB_PASSWORD
+      - run:
+          name: Push to DockerHub
+          command: docker push romppane/bulletin-board:$CIRCLE_SHA1
+      - run:
+          name: Login to registery
+          command: docker login --username=$HEROKU_LOGIN --$HEROKU_API_KEY registery.heroku.com
+      - run:
+          name: Deploy to Heroku
+          command: docker tag romppane/bulletin-board:$CIRCLE_SHA1 registery.heroku.com/$HEROKU_APP_NAME/web
 
 workflows:
   btd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 executors:
   my-executor:
     docker:
-      - image: circleci/node:10.15.3
+      - image: circleci/node:10.16.1
     working_directory: ~/repo
 
 jobs:
@@ -70,6 +70,13 @@ jobs:
           name: Release on Heroku
           command: docker push registry.heroku.com/$HEROKU_APP_NAME/web
 
+  release:
+    executor: my-executor
+    steps:
+      - run: sudo snap install --classic heroku
+      - run: heroku login -u $HEROKU_LOGIN -p $HEROKU_API_KEY
+      - run: heroku container:release web
+
 workflows:
   btd:
     jobs:
@@ -83,3 +90,6 @@ workflows:
       - deploy:
           requires:
             - compile
+      - release:
+          requires:
+            - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
   release:
     executor: my-executor
     steps:
-      - run: sudo snap install --classic heroku
+      - run: curl https://cli-assets.heroku.com/install.sh | sh
       - run: heroku login -u $HEROKU_LOGIN -p $HEROKU_API_KEY
       - run: heroku container:release web
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
     executor: my-executor
     steps:
       - run: curl https://cli-assets.heroku.com/install.sh | sh
-      - run: heroku login -u $HEROKU_LOGIN -p $HEROKU_API_KEY
+      - run: heroku login $HEROKU_API_KEY
       - run: heroku container:release web
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           command: docker tag romppane/bulletin-board:$CIRCLE_SHA1 registry.heroku.com/$HEROKU_APP_NAME/web
       - run:
           name: Release on Heroku
-          command: heroku container:release web
+          command: docker push registry.heroku.com/$HEROKU_APP_NAME/web
 
 workflows:
   btd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,6 @@ jobs:
     executor: my-executor
     steps:
       - run: curl https://cli-assets.heroku.com/install.sh | sh
-      - run: heroku login -i
-      - run: $HEROKU_LOGIN
-      - run: $HEROKU_API_KEY
       - run: heroku container:release web
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,12 @@ jobs:
       - run:
           name: Update npm
           command: 'sudo npm install -g npm@latest'
-      # Install dependencies
       - run:
-          name: Install npm wee
+          name: Install npm
           command: npm install
+      - run:
+          name: Compile
+          command: npm run tsc
       - persist_to_workspace:
           root: ~/repo
           key: dependency-cache-{{ checksum "package.json" }}
@@ -35,14 +37,6 @@ jobs:
       - attach_workspace:
           at: ~/repo
       - run: npm test
-
-  compile:
-    executor: my-executor
-    steps:
-      - checkout
-      - attach_workspace:
-          at: ~/repo
-      - run: npm run tsc
 
   deploy:
     executor: my-executor
@@ -67,14 +61,14 @@ jobs:
           name: Deploy to Heroku
           command: docker tag romppane/bulletin-board:$CIRCLE_SHA1 registry.heroku.com/$HEROKU_APP_NAME/web
       - run:
-          name: Release on Heroku
+          name: Push to Heroku
           command: docker push registry.heroku.com/$HEROKU_APP_NAME/web
-
-  release:
-    executor: my-executor
-    steps:
-      - run: curl https://cli-assets.heroku.com/install.sh | sh
-      - run: heroku container:release web -a bulletin-board-onboarding-api
+      - run:
+          name: Download HerokuCLI
+          command: curl https://cli-assets.heroku.com/install.sh | sh
+      - run:
+          name: Release the changes in Heroku
+          command: heroku container:release web -a bulletin-board-onboarding-api
 
 workflows:
   btd:
@@ -83,15 +77,6 @@ workflows:
       - test:
           requires:
             - build
-      - compile:
+      - deploy:
           requires:
             - test
-      - deploy:
-          filters:
-            branches:
-              only: master
-          requires:
-            - compile
-      - release:
-          requires:
-            - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
       - run: npm run tsc
 
   deploy:
+    machine: true
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,9 @@ jobs:
       - run:
           name: Deploy to Heroku
           command: docker tag romppane/bulletin-board:$CIRCLE_SHA1 registry.heroku.com/$HEROKU_APP_NAME/web
+      - run:
+        name: Release on Heroku
+        command: heroku container:release web
 
 workflows:
   btd:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 .git
-.env
 .vscode
 node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .git
-build
 .env
 .vscode
 node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ RUN npm install
 
 COPY . .
 
-RUN npm run tsc
-
 EXPOSE 3000
 
 ## Waits for database connection to be ready for receiving connections

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.2.1/wait
 RUN chmod +x /wait
 
 ## Launch the wait tool and then your application
-CMD ["npm" "start"]
+CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN npm install
 
 COPY . .
 
+RUN npm run tsc
+
 EXPOSE 3000
 
 ## Waits for database connection to be ready for receiving connections
@@ -16,4 +18,4 @@ ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.2.1/wait
 RUN chmod +x /wait
 
 ## Launch the wait tool and then your application
-CMD /wait && npm run dev
+CMD ["npm" "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     image: bulletin-board
     depends_on:
       - database
+    command: sh -c "/wait && npm run dev"
     volumes:
       - './server:/app/server'
     environment:

--- a/package-lock.json
+++ b/package-lock.json
@@ -462,15 +462,6 @@
         "@types/node": "*"
       }
     },
-    "@types/dotenv": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.1.tgz",
-      "integrity": "sha512-ftQl3DtBvqHl9L16tpqqzA4YzCSXZfi7g8cQceTz5rOlYtk/IZbFjAv3mLOQlNIgOaylCQWQoBdDQHPgEBJPHg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -1643,11 +1634,6 @@
         "webidl-conversions": "^4.0.2"
       }
     },
-    "dotenv": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
-      "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg=="
-    },
     "dynamic-dedupe": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
@@ -2131,7 +2117,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2152,12 +2139,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2172,17 +2161,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2299,7 +2291,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2311,6 +2304,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2325,6 +2319,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2332,12 +2327,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2356,6 +2353,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2436,7 +2434,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2448,6 +2447,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2533,7 +2533,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2569,6 +2570,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2588,6 +2590,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2631,12 +2634,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,13 +6,11 @@
   "scripts": {
     "tsc": "tsc",
     "dev": "ts-node-dev --poll --respawn --transpileOnly ./server/start-server.ts",
-    "prod": "tsc && node ./build/start-server.js",
     "test": "jest",
-    "postinstall": "npm run tsc",
     "start": "node ./build/start-server.js"
   },
   "engines": {
-    "node": "10.15.3"
+    "node": "10.16.1"
   },
   "repository": {
     "type": "git",
@@ -33,7 +31,6 @@
     "awilix": "^4.2.2",
     "class-transformer": "^0.2.3",
     "class-validator": "^0.10.0-rc.1",
-    "dotenv": "^8.0.0",
     "express": "^4.17.1",
     "moment-timezone": "^0.5.26",
     "morgan": "^1.9.1",
@@ -45,7 +42,6 @@
   },
   "devDependencies": {
     "@types/boom": "^7.2.1",
-    "@types/dotenv": "^6.1.1",
     "@types/express": "^4.17.0",
     "@types/glob": "^7.1.1",
     "@types/hapi__boom": "^7.4.0",

--- a/readme.MD
+++ b/readme.MD
@@ -27,5 +27,3 @@ Your project should now be good to run.
 ```
 $ docker-compose up
 ```
-
-When ever you make a change in your code, run the command again in order to make it live!


### PR DESCRIPTION
Dockerfile now by default makes an image that can be run in production environment while the docker-compose lets the developer use dev environment locally.

CircleCI now builds and pushes the image to Heroku and Docker Hub and finally releases the new image to be used in Heroku!

Helpful links:
Configure Dockerfile and compose: https://dev.to/alex_barashkov/using-docker-for-nodejs-in-development-and-production-3cgp
How to push docker images to the cloud: https://chatbotsmagazine.com/create-a-ci-cd-pipeline-with-circleci-to-deploy-your-bot-in-a-docker-image-to-heroku-32f5dfe887
Install HerokuCLI inside image: https://devcenter.heroku.com/articles/heroku-cli#download-and-install

Overall the whole process didn't seem all that well documented and many things people had done in the past didn't seem to work all that well with the new updates of Heroku. For me it almost seems they don't want for people to be doing releases this way and instead try to push users to using their own pipelines instead!?